### PR TITLE
chore: leverage `nixpkgs.lib.getExe`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -109,10 +109,10 @@
             mkdir -p $out
             echo "NixOS Autofirma Sign Test" > document.txt
 
-            ${pkgs.openssl}/bin/openssl req -x509 -newkey rsa:2048 -keyout private.key -out certificate.crt -days 365 -nodes -subj "/C=ES/O=TEST AUTOFIRMA NIX/OU=DNIE/CN=AC DNIE 004" -passout pass:1234
-            ${pkgs.openssl}/bin/openssl pkcs12 -export -out certificate.p12 -inkey private.key -in certificate.crt -name "testcert" -password pass:1234
+            ${inputs.nixpkgs.lib.getExe pkgs.openssl} req -x509 -newkey rsa:2048 -keyout private.key -out certificate.crt -days 365 -nodes -subj "/C=ES/O=TEST AUTOFIRMA NIX/OU=DNIE/CN=AC DNIE 004" -passout pass:1234
+            ${inputs.nixpkgs.lib.getExe pkgs.openssl} pkcs12 -export -out certificate.p12 -inkey private.key -in certificate.crt -name "testcert" -password pass:1234
 
-            ${self'.packages.autofirma}/bin/autofirma sign -store pkcs12:certificate.p12 -i document.txt -o document.txt.sign -filter alias.contains=testcert -password 1234 -xml
+            ${inputs.nixpkgs.lib.getExe self'.packages.autofirma} sign -store pkcs12:certificate.p12 -i document.txt -o document.txt.sign -filter alias.contains=testcert -password 1234 -xml
           '';
         };
       };


### PR DESCRIPTION
Apply current best practice of obtaining the path to the main binary via `meta.mainProgram`.