### PR TITLE
Automatic synchronization of release branches with main

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+flake.nix merge=ours
+flake.lock merge=ours

--- a/.github/workflows/sync-releases-with-main.yml
+++ b/.github/workflows/sync-releases-with-main.yml
@@ -1,0 +1,29 @@
+name: Sync releases with main
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  sync-release-branches:
+    strategy:
+      matrix:
+        version: ["23.11", "24.05"]
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        ref: "release-${{ matrix.version }}"
+    - run: |
+        git config --global merge.ours.driver true
+        git config --global user.name 'autofirma-nix-bot'
+        git config --global user.email 'autofirma-nix-bot@users.noreply.github.com'
+        git config --global pull.rebase false
+    - run: git merge --no-ff origin/main
+    - run: git push
+
+


### PR DESCRIPTION
This pull request introduces a new GitHub workflow that runs on every push to the main branch, merging the new commits into the release-23.11 and release-24.05 branches.

A merge policy is in place to always favor the changes in the release-* branches in case of a conflict in the files flake.lock and flake.nix, which are the only diverging files at this time.

If, in the future, the release-* branches diverge from the main branch due to changes in the nixpkgs/home-manager API, we will discuss decommissioning the affected branches from this workflow, or other appropriate actions.