### PR TITLE
fix: do not garbage collect nss-tools until uninstall is removed

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,15 @@ $ autofirma-setup
 
 Después es necesario reiniciar Firefox para que los cambios surtan efecto.
 
+### Desinstalación de certificados
+
+Si se desea desinstalar los certificados creados por `autofirma-setup`, se puede
+ejecutar el siguiente comando:
+
+```
+$ autofirma-setup --uninstall
+```
+
 ## Solución de problemas
 
 ### Los dispositivos de seguridad no parecen actualizarse


### PR DESCRIPTION
**Problem:**

The `autofirma-setup` script creates several scripts in the `$HOME/.afirma/AutoFirma` directory. These scripts execute using the specific version of `nss.tools` that was used to compile `AutoFirma`.

Even if AutoFirma is uninstalled or updated to a new version that relies on a different version of `nss-tools`, we must retain the `nss-tools` version required by the existing scripts.

**Proposed Solution:**

1. When `autofirma-setup` runs, it will create a `gcroot` in the `$HOME/.afirma/AutoFirma` directory, linking to the `nss-tools` version required by the setup scripts.
2. If the user deletes the `$HOME/.afirma/AutoFirma` directory, the next nix-garbage-collect operation will remove the now-unnecessary `nss-tools` version.
3. If `autofirma-setup` is executed again, it will generate a new set of certificates and replace everything with the current version of `nss-tools`.
4. A new flag, `autofirma-setup --uninstall`, will be added to allow users to uninstall the certificates. This command will remove all generated files, including the gcroot.