### PR TITLE
feat: add options to disable version checking

### DIFF
--- a/nix/autofirma/default.nix
+++ b/nix/autofirma/default.nix
@@ -17,6 +17,8 @@
   src-rev,
   src-hash,
   maven-dependencies-hash ? "",
+  disableJavaVersionCheck ? true,
+  disableAutoFirmaVersionCheck ? true,
 }: let
   name = "autofirma";
 
@@ -43,7 +45,9 @@
       ./patches/clienteafirma/detect_java_version.patch
       ./patches/clienteafirma/pr-367.patch
       ./patches/clienteafirma/certutilpath.patch
-    ];
+    ] ++ (lib.optional disableJavaVersionCheck [
+      ./patches/clienteafirma/dont_check_java_version.patch
+    ]);
 
     dontBuild = true;
 
@@ -174,6 +178,7 @@
         --replace /usr/bin/autofirma $out/bin/autofirma
 
       makeWrapper ${jre}/bin/java $out/bin/autofirma \
+        --set AUTOFIRMA_AVOID_UPDATE_CHECK ${lib.boolToString disableAutoFirmaVersionCheck} \
         --add-flags "-Des.gob.afirma.keystores.mozilla.UseEnvironmentVariables=true" \
         --add-flags "-jar $out/lib/AutoFirma/AutoFirma.jar"
 

--- a/nix/autofirma/patches/clienteafirma/dont_check_java_version.patch
+++ b/nix/autofirma/patches/clienteafirma/dont_check_java_version.patch
@@ -1,0 +1,12 @@
+diff --git a/afirma-simple/src/main/java/es/gob/afirma/standalone/SimpleAfirma.java b/afirma-simple/src/main/java/es/gob/afirma/standalone/SimpleAfirma.java
+index 22b2cd997..3e52d8a07 100644
+--- a/afirma-simple/src/main/java/es/gob/afirma/standalone/SimpleAfirma.java
++++ b/afirma-simple/src/main/java/es/gob/afirma/standalone/SimpleAfirma.java
+@@ -1021,7 +1021,6 @@ public final class SimpleAfirma implements PropertyChangeListener, WindowListene
+ 				LOGGER.info("Iniciando entorno grafico"); //$NON-NLS-1$
+ 				saf.initGUI(null);
+ 
+-				checkJavaVersion(saf.getMainFrame());
+ 			} else {
+ 				LOGGER.log(Level.WARNING, "La aplicacion ya se encuentra activa en otra ventana. Se cerrara esta instancia"); //$NON-NLS-1$
+ 	    		AOUIFactory.showErrorMessage(SimpleAfirmaMessages.getString("SimpleAfirma.3"), //$NON-NLS-1$


### PR DESCRIPTION
With this PR the default AutoFirma derivation will no longer check the Java nor AutoFirma version.

The checks can be individually enabled by a package override.